### PR TITLE
Support configuration of absolute sitemap urls.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,8 @@ Changelog
 1.1 (unreleased)
 ----------------
 
+- Support configuration of absolute sitemap urls. [jone]
+
 - Slow down on too many requests. [jone]
 
 


### PR DESCRIPTION
Adds support for configuring absolute URLs to the sitemap or the sitemap index rather than to the root of the website and then using auto-discovery. This adds support for non-standard sitemap URLs.
