### PR TITLE
Support slack notifications

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -144,6 +144,25 @@ argument to ``bin/crawl-foo-org``. The crawler will then only fetch and index
 that specific URL.
 
 
+Slack-Notifications
+-------------------
+
+The ``ftw.crawler`` supports Slack-Notifications. Those notifications can be used
+to monitor the crawler on possible errors while crawling.
+To enable slack-notifications for your environment, you need to do the following things:
+
+- Make sure `slacker <https://github.com/os/slacker>`_ is installed in your env.
+- Set the `SLACK_TOKEN` and the `SLACK_CHANNEL` params in your crawler config or
+- use the `--slacktoken` and the `--slackchannel` arguments in the command line when
+  calling the `/crawl` script.
+
+To generate a valid slack token for your integration, you have to create a new bot in
+your slack-team. After you generated the new bot slack will automatically generate a
+valid token for this bot. This token can then be used for your integration.
+You can also generate a test token to test your integration, but don't forget to create
+a bot for this if your application goes to production!
+
+
 Development
 -----------
 

--- a/README.rst
+++ b/README.rst
@@ -147,11 +147,11 @@ that specific URL.
 Slack-Notifications
 -------------------
 
-The ``ftw.crawler`` supports Slack-Notifications. Those notifications can be used
+``ftw.crawler`` supports Slack-Notifications. Those notifications can be used
 to monitor the crawler on possible errors while crawling.
 To enable slack-notifications for your environment, you need to do the following things:
 
-- Make sure `slacker <https://github.com/os/slacker>`_ is installed in your env.
+- Install ``ftw.crawler`` with the ``slack`` extra.
 - Set the `SLACK_TOKEN` and the `SLACK_CHANNEL` params in your crawler config or
 - use the `--slacktoken` and the `--slackchannel` arguments in the command line when
   calling the `/crawl` script.

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.1.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Support Slack notifications.
+  [raphael-s]
 
 
 1.1.0 (2016-10-04)

--- a/ftw/crawler/__init__.py
+++ b/ftw/crawler/__init__.py
@@ -16,6 +16,10 @@ def parse_args(argv=None):
                         nargs='?', default=None)
     parser.add_argument('--tika', help='Base URL to Tika', metavar='TIKA_URL')
     parser.add_argument('--solr', help='Base URL to Solr', metavar='SOLR_URL')
+    parser.add_argument('--slacktoken', help='Token for Slack messages',
+                        metavar='SLACK_TOKEN')
+    parser.add_argument('--slackchannel', help='Channel for Slack messages',
+                        metavar='SLACK_CHANNEL')
     parser.add_argument('-f', '--force', help="Force crawling even if"
                         "document hasn't been modified", action='store_true')
     args = parser.parse_args(argv)

--- a/ftw/crawler/configuration.py
+++ b/ftw/crawler/configuration.py
@@ -15,6 +15,11 @@ def get_config(options):
         config.tika = options.tika
     if options.solr:
         config.solr = options.solr
+    # Command line options for SlackToken & SlackChannel override config values
+    if options.slacktoken:
+        config.slacktoken = options.slacktoken
+    if options.slackchannel:
+        config.slackchannel = options.slackchannel
 
     if not (config.tika and config.solr):
         raise ValueError(
@@ -27,7 +32,8 @@ def get_config(options):
 class Config(object):
 
     def __init__(self, sites, unique_field, url_field, last_modified_field,
-                 fields, tika=None, solr=None):
+                 fields, tika=None, solr=None,
+                 slacktoken=None, slackchannel=None):
         self.sites = sites
         self.unique_field = unique_field
         self.url_field = url_field
@@ -35,6 +41,8 @@ class Config(object):
         self.fields = fields
         self.tika = tika
         self.solr = solr
+        self.slacktoken = slacktoken
+        self.slackchannel = slackchannel
 
         for site in self.sites:
             site.bind(self)

--- a/ftw/crawler/configuration.py
+++ b/ftw/crawler/configuration.py
@@ -10,12 +10,11 @@ def get_config(options):
     module = imp.load_source(module_name, config_path)
     config = module.CONFIG
 
-    # Command line options for Tika and Solr override config values
+    # Command line overrides for config options
     if options.tika:
         config.tika = options.tika
     if options.solr:
         config.solr = options.solr
-    # Command line options for SlackToken & SlackChannel override config values
     if options.slacktoken:
         config.slacktoken = options.slacktoken
     if options.slackchannel:

--- a/ftw/crawler/main.py
+++ b/ftw/crawler/main.py
@@ -8,14 +8,15 @@ from ftw.crawler.fetcher import ResourceFetcher
 from ftw.crawler.purging import purge_removed_docs_from_index
 from ftw.crawler.resource import ResourceInfo
 from ftw.crawler.sitemap import SitemapIndexFetcher
-from ftw.crawler.solr import solr_escape
 from ftw.crawler.solr import SolrConnector
+from ftw.crawler.solr import solr_escape
 from ftw.crawler.tika import TikaConverter
 from ftw.crawler.utils import from_iso_datetime
 import logging
 import os
 import requests
 import shutil
+import sys
 import tempfile
 
 
@@ -54,77 +55,102 @@ def get_indexing_time(url, indexed_docs, config):
 def crawl_and_index(tempdir, config, options):
     solr = SolrConnector(config.solr)
 
+    try:
+        from slack import SlackLogger
+        SlackLogger = SlackLogger(options.slacktoken)
+        HAS_SLACK = True
+    except ImportError:
+        log.warning('Slacker not found')
+        HAS_SLACK = False
+
     for site in config.sites:
         # Skip non-matching sites if we're only indexing a specific URL
         if options.url and not options.url.startswith(site.url):
             continue
 
-        # Fetch and parse the sitemap index (or build a virtual one)
-        sitemap_index = SitemapIndexFetcher(site).fetch()
+        try:
+            crawl_site(tempdir, config, options, solr, site)
+        except KeyboardInterrupt:
+            sys.exit(0)
+        except Exception as ex:
+            log.error('Failed to crawl {}'.format(site.url))
+            log.error('{}: {}'.format(type(ex).__name__, str(ex.message)))
+            log.info('Continuing with next site...')
+            if HAS_SLACK:
+                SlackLogger.logError(ex, site, options.slackchannel)
+            continue
 
-        log.info(u"Crawling {} [{} sitemap(s)]...".format(
-            site.url, len(sitemap_index.sitemaps)))
 
-        # Get all docs indexed in Solr for a particular site
-        indexed_docs = get_indexed_docs(config, solr, site)
+def crawl_site(tempdir, config, options, solr, site):
+    # Fetch and parse the sitemap index (or build a virtual one)
+    sitemap_index = SitemapIndexFetcher(site).fetch()
 
-        # Purge docs that have been removed from sitemap(s) from Solr index
-        purge_removed_docs_from_index(config, sitemap_index, indexed_docs)
+    log.info(u"Crawling {} [{} sitemap(s)]...".format(
+        site.url, len(sitemap_index.sitemaps)))
 
-        # Create a requests session to allow for connection pooling
-        fetcher_session = requests.Session()
+    # Get all docs indexed in Solr for a particular site
+    indexed_docs = get_indexed_docs(config, solr, site)
 
-        for sitemap in sitemap_index.sitemaps:
-            total = len(sitemap.url_infos)
+    # Purge docs that have been removed from sitemap(s) from Solr index
+    purge_removed_docs_from_index(config, sitemap_index, indexed_docs)
 
-            log.info(u"-" * 78)
-            log.info(u"Crawling {}...".format(sitemap.url))
+    # Create a requests session to allow for connection pooling
+    fetcher_session = requests.Session()
 
-            for n, url_info in enumerate(sitemap.url_infos, start=1):
-                url = url_info['loc']
-                progress = '[{}/{}]'.format(n, total)
+    for sitemap in sitemap_index.sitemaps:
+        total = len(sitemap.url_infos)
 
-                # If we're only indexing a specific URL, skip all others
-                if options.url and not url == options.url:
-                    continue
+        log.info(u"-" * 78)
+        log.info(u"Crawling {}...".format(sitemap.url))
 
-                log.debug(u"{}: {}".format(url, unicode(url_info)))
+        for n, url_info in enumerate(sitemap.url_infos, start=1):
+            url = url_info['loc']
+            progress = '[{}/{}]'.format(n, total)
 
-                # Get time this document was last indexed
-                last_indexed = get_indexing_time(url, indexed_docs, config)
+            # If we're only indexing a specific URL, skip all others
+            if options.url and not url == options.url:
+                continue
 
-                # Fetch and save resource
-                resource_info = ResourceInfo(site=sitemap.site,
-                                             url_info=url_info,
-                                             last_indexed=last_indexed)
-                fetcher = ResourceFetcher(
-                    resource_info, fetcher_session, tempdir, options)
-                try:
-                    resource_info = fetcher.fetch()
-                except NotModified:
-                    log.info(u"{}   Skipped {} (not modified)".format(progress, url))
-                    continue
-                except AttemptedRedirect:
-                    continue
-                except FetchingError, e:
-                    log.error(unicode(e))
-                    continue
+            log.debug(u"{}: {}".format(url, unicode(url_info)))
 
-                # Extract metadata and plain text
-                engine = ExtractionEngine(
-                    config, resource_info, converter=TikaConverter(config.tika))
-                field_values = engine.extract_field_values()
-                display_fields(field_values)
-                os.unlink(resource_info.filename)
+            # Get time this document was last indexed
+            last_indexed = get_indexing_time(url, indexed_docs, config)
 
-                # Index into Solr
-                log.debug(u"Indexing {} into solr.".format(url))
-                response = solr.index(field_values)
-                if response.status_code == 200:
-                    log.info(u"{} * Indexed {}".format(progress, url))
+            # Fetch and save resource
+            resource_info = ResourceInfo(site=sitemap.site,
+                                         url_info=url_info,
+                                         last_indexed=last_indexed)
+            fetcher = ResourceFetcher(
+                resource_info, fetcher_session, tempdir, options)
+            try:
+                resource_info = fetcher.fetch()
+            except NotModified:
+                log.info(u"{}   Skipped {} (not modified)".format(progress,
+                                                                  url))
+                continue
+            except AttemptedRedirect:
+                continue
+            except FetchingError, e:
+                log.error(unicode(e))
+                continue
+            except Exception as ex:
+                print ex
 
-        log.info(u"=" * 78)
-        log.info(u"")
+            # Extract metadata and plain text
+            engine = ExtractionEngine(
+                config, resource_info, converter=TikaConverter(config.tika))
+            field_values = engine.extract_field_values()
+            display_fields(field_values)
+            os.unlink(resource_info.filename)
+
+            # Index into Solr
+            log.debug(u"Indexing {} into solr.".format(url))
+            response = solr.index(field_values)
+            if response.status_code == 200:
+                log.info(u"{} * Indexed {}".format(progress, url))
+
+    log.info(u"=" * 78)
+    log.info(u"")
 
 
 def main():

--- a/ftw/crawler/slack.py
+++ b/ftw/crawler/slack.py
@@ -1,0 +1,55 @@
+import json
+
+try:
+    from slacker import Slacker
+except ImportError:
+    raise ImportError
+
+
+class SlackLogger(object):
+    def __init__(self, slacktoken):
+        self.slack = Slacker(slacktoken)
+
+    def logError(self, ex, site, channel):
+        text = "Error while crawling external site indexes!"
+
+        attdata = self.generateAttdata(ex, site)
+        channel = self.checkChannel(channel)
+
+        self.send(text, attdata, channel)
+
+    def checkChannel(self, channel):
+        if not channel.startswith('#'):
+            channel = '#' + channel
+        return channel
+
+    def generateAttdata(self, ex, site):
+        return json.dumps(
+            [
+                {
+                    "color": 'danger',
+                    "fields": [
+                        {
+                            "title": "Site",
+                            "value": site.url
+                        },
+                        {
+                            "title": "Exception Type",
+                            "value": type(ex).__name__
+                        },
+                        {
+                            "title": "Error Message",
+                            "value": str(ex.message)
+                        }
+                    ]
+                }
+            ]
+        )
+
+    def send(self, text, attdata, channel):
+        username = self.slack.auth.test().body['user']
+        self.slack.chat.post_message(channel,
+                                     text,
+                                     as_user=username,
+                                     link_names=1,
+                                     attachments=attdata)

--- a/ftw/crawler/slack.py
+++ b/ftw/crawler/slack.py
@@ -1,9 +1,15 @@
 import json
+import pkg_resources
+
 
 try:
+    pkg_resources.get_distribution('slacker')
+except pkg_resources.DistributionNotFound:
+    # To use this module you have to install slacker
+    raise ImportError('Please install the extra "slack" to use slack '
+                      'integration')
+else:
     from slacker import Slacker
-except ImportError:
-    raise ImportError
 
 
 class SlackLogger(object):

--- a/ftw/crawler/tests/assets/basic_config.py
+++ b/ftw/crawler/tests/assets/basic_config.py
@@ -34,6 +34,8 @@ OBJECT_TYPE_MAPPING = {
 # May be overriden via command line arguments
 TIKA_URL = 'http://localhost:9998/'
 SOLR_URL = 'http://localhost:8983/solr'
+SLACK_TOKEN = 'this-is-a-slack-token'
+SLACK_CHANNEL = '#slack-channel'
 
 
 CONFIG = Config(
@@ -113,4 +115,6 @@ CONFIG = Config(
     ],
     tika=TIKA_URL,
     solr=SOLR_URL,
+    slacktoken=SLACK_TOKEN,
+    slackchannel=SLACK_CHANNEL,
 )

--- a/ftw/crawler/tests/test_configuration.py
+++ b/ftw/crawler/tests/test_configuration.py
@@ -19,6 +19,8 @@ class TestConfig(CrawlerTestCase):
         self.site = Site('http://example.org')
         self.tika = 'http://localhost:9998'
         self.solr = 'http://localhost:8983/solr'
+        self.slacktoken = 'token'
+        self.slackchannel = '#channel'
         self.unique_field = 'UID'
         self.url_field = 'url'
         self.last_modified_field = 'modified'
@@ -26,7 +28,8 @@ class TestConfig(CrawlerTestCase):
 
         self.config = Config([self.site], self.unique_field, self.url_field,
                              self.last_modified_field, [self.field],
-                             self.tika, self.solr)
+                             self.tika, self.solr,
+                             self.slacktoken, self.slackchannel)
 
     def test_config_stores_sites(self):
         self.assertEquals([self.site], self.config.sites)
@@ -36,6 +39,12 @@ class TestConfig(CrawlerTestCase):
 
     def test_config_stores_solr(self):
         self.assertEquals(self.solr, self.config.solr)
+
+    def test_config_stores_slacktoken(self):
+        self.assertEquals(self.slacktoken, self.config.slacktoken)
+
+    def test_config_stores_slackchannel(self):
+        self.assertEquals(self.slackchannel, self.config.slackchannel)
 
     def test_config_stores_unique_field(self):
         self.assertEquals(self.unique_field, self.config.unique_field)
@@ -116,16 +125,20 @@ class TestField(CrawlerTestCase):
 class TestGetConfig(CrawlerTestCase):
 
     def test_get_config_loads_config_module_and_returns_config_instance(self):
-        options = Namespace(tika=None, solr=None)
+        options = Namespace(tika=None, solr=None,
+                            slacktoken=None, slackchannel=None)
         options.config = BASIC_CONFIG
 
         config = get_config(options)
         self.assertIsInstance(config, Config)
 
-    def test_get_config_sets_tika_and_solr_from_command_line(self):
-        options = Namespace(tika='http://tika', solr='http://solr')
+    def test_get_config_sets_arguments_from_command_line(self):
+        options = Namespace(tika='http://tika', solr='http://solr',
+                            slacktoken='token', slackchannel='#channel')
         options.config = BASIC_CONFIG
 
         config = get_config(options)
         self.assertEquals('http://tika', config.tika)
         self.assertEquals('http://solr', config.solr)
+        self.assertEquals('token', config.slacktoken)
+        self.assertEquals('#channel', config.slackchannel)

--- a/ftw/crawler/tests/test_extractors.py
+++ b/ftw/crawler/tests/test_extractors.py
@@ -82,7 +82,8 @@ class TestExtractionEngine(CrawlerTestCase):
 
     def setUp(self):
         CrawlerTestCase.setUp(self)
-        args = Namespace(tika=None, solr=None)
+        args = Namespace(tika=None, solr=None,
+                         slacktoken=None, slackchannel=None)
         args.config = BASIC_CONFIG
         self.config = deepcopy(get_config(args))
 

--- a/ftw/crawler/tests/test_purging.py
+++ b/ftw/crawler/tests/test_purging.py
@@ -17,7 +17,8 @@ class TestPurging(SolrTestCase, SitemapTestCase):
     def setUp(self):
         SolrTestCase.setUp(self)
         SitemapTestCase.setUp(self)
-        args = Namespace(tika=None, solr=None)
+        args = Namespace(tika=None, solr=None,
+                         slacktoken=None, slackchannel=None)
         args.config = BASIC_CONFIG
         self.config = deepcopy(get_config(args))
         self.config.url_field = 'url'

--- a/ftw/crawler/tests/test_slack.py
+++ b/ftw/crawler/tests/test_slack.py
@@ -1,0 +1,38 @@
+from ftw.crawler.testing import CrawlerTestCase
+from ftw.crawler.slack import SlackLogger
+from ftw.crawler.configuration import Site
+import json
+
+
+class TestSlack(CrawlerTestCase):
+    def setUp(self):
+        CrawlerTestCase.setUp(self)
+        self.token = 'this-is-a-slack-token'
+        self.slacklogger = SlackLogger(self.token)
+
+    def test_slack_token_required_for_logger_init(self):
+        with self.assertRaises(TypeError):
+            SlackLogger()
+
+    def test_slack_can_handle_all_channels(self):
+        # The channel-name always needs a # infornt of it
+        no_hashtag = self.slacklogger.checkChannel('no-hashtag')
+        hashtag = self.slacklogger.checkChannel('#hashtag')
+
+        self.assertEquals('#no-hashtag', no_hashtag)
+        self.assertEquals('#hashtag', hashtag)
+
+    def test_slack_can_format_json_from_data(self):
+        ex = Exception('error message')
+        site = Site('http://some-url.com/')
+
+        data = json.loads(self.slacklogger.generateAttdata(ex, site))[0]
+
+        self.assertEquals("http://some-url.com/",
+                          data['fields'][0]['value'])
+
+        self.assertEquals("Exception",
+                          data['fields'][1]['value'])
+
+        self.assertEquals("error message",
+                          data['fields'][2]['value'])

--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,10 @@ tests_require = [
     'unittest2',
     'mock',
     'testfixtures',
+    'ftw.crawler [slack]',
+]
+
+slack_requires = [
     'slacker',
 ]
 
@@ -42,11 +46,11 @@ setup(name='ftw.crawler',
           'pytz',
           'python-slugify',
           'BeautifulSoup',
-          'chardet',
+          'chardet'
       ],
 
       tests_require=tests_require,
-      extras_require=dict(tests=tests_require),
+      extras_require=dict(tests=tests_require, slack=slack_requires),
 
       entry_points='''
       [console_scripts]

--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,7 @@ tests_require = [
     'unittest2',
     'mock',
     'testfixtures',
+    'slacker',
 ]
 
 setup(name='ftw.crawler',

--- a/versions-dev.cfg
+++ b/versions-dev.cfg
@@ -20,6 +20,7 @@ pep8 = 1.6.2
 pyasn1 = 0.1.9
 pyflakes = 1.0.0
 requests = 2.8.1
+slacker = 0.9.30
 testfixtures = 4.10.1
 unittest2 = 1.1.0
 z3c.dependencychecker = 1.15


### PR DESCRIPTION
Adds support for slack notifications.

If slacker is installed and the slack-attributes are set, this will automatically send notifications to slack when crawler raises an error while crawling.