### PR TITLE
Use url base (scheme, netloc) for purge query.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 1.1.1 (unreleased)
 ------------------
 
+- Use url base (scheme, netloc) for purge query.
+  [mathias.leimgruber]
+
 - Support Slack notifications.
   [raphael-s]
 

--- a/ftw/crawler/configuration.py
+++ b/ftw/crawler/configuration.py
@@ -1,5 +1,6 @@
 from ftw.crawler.exceptions import NoSuchField
 from ftw.crawler.exceptions import SiteNotFound
+from urlparse import urlparse
 import imp
 import os
 
@@ -74,6 +75,11 @@ class Site(object):
 
     def bind(self, config):
         self.config = config
+
+    @property
+    def base_url(self):
+        parsed_url = urlparse(self.url)
+        return '{url.scheme}://{url.netloc}'.format(url=parsed_url)
 
 
 class Field(object):

--- a/ftw/crawler/main.py
+++ b/ftw/crawler/main.py
@@ -47,7 +47,7 @@ def display_fields(field_values):
 
 
 def get_indexed_docs(config, solr, site):
-    query = '{}:{}*'.format(config.url_field, solr_escape(site.url))
+    query = '{}:{}*'.format(config.url_field, solr_escape(site.base_url))
     indexed_docs = solr.search(
         query,
         fl=(config.unique_field, config.url_field, config.last_modified_field))

--- a/ftw/crawler/purging.py
+++ b/ftw/crawler/purging.py
@@ -17,8 +17,7 @@ def purge_removed_docs_from_index(config, sitemap_index, indexed_docs):
     for doc in indexed_docs:
         url = doc[url_field]
         uid = doc[unique_field]
-
-        url_in_site = url.startswith(site.url)
+        url_in_site = url.startswith(site.base_url)
         url_in_any_sitemap = any(url in sm for sm in sitemap_index.sitemaps)
 
         if url_in_site and not url_in_any_sitemap:

--- a/ftw/crawler/tests/assets/basic_config.py
+++ b/ftw/crawler/tests/assets/basic_config.py
@@ -54,6 +54,9 @@ CONFIG = Config(
 
         Site('https://bgs.zg.ch',
              attributes={'site_area': 'Gesetzessammlung'}),
+
+        Site('https://dummy.kanton.ch/some_index.php?id=123456',
+             attributes={'site_area': 'Kanton'}),
     ],
     unique_field='UID',
     url_field='path_string',

--- a/ftw/crawler/tests/test_purging.py
+++ b/ftw/crawler/tests/test_purging.py
@@ -59,3 +59,22 @@ class TestPurging(SolrTestCase, SitemapTestCase):
         purge_removed_docs_from_index(self.config, sitemap_index, indexed_docs)
 
         self.assertEquals(0, delete.call_count)
+
+    @patch('ftw.crawler.solr.SolrConnector.delete')
+    def test_get_docs_by_scheme_and_netloc(self, delete):
+        indexed_docs = [
+            {'UID': '1', 'url': 'https://dummy.kanton.ch/download'},
+            {'UID': '2', 'url': 'https://dummy.kanton.ch/about'},
+            {'UID': '3', 'url': 'https://dummy.kantons.ch/url'},
+        ]
+        dummy = self.config.get_site(
+            'https://dummy.kanton.ch/some_index.php?id=123456')
+
+        sitemap = self.create_sitemap(
+            urls=['https://dummy.kantons.ch/url'],
+            site=dummy)
+
+        sitemap_index = VirtualSitemapIndex(dummy, sitemaps=[sitemap])
+        purge_removed_docs_from_index(self.config, sitemap_index, indexed_docs)
+
+        self.assertEquals(2, delete.call_count)


### PR DESCRIPTION
Before the query failed with URLs like `https://dummy.kanton.ch/some_index.php?id=123456`