### PR TITLE
Encode url in UTF-8 before generation MD5-Hash of it.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.2.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Encode URL in UTF-8 before generating MD5-Hash.
+  [raphael-s]
 
 
 1.2.0 (2017-06-22)

--- a/ftw/crawler/extractors.py
+++ b/ftw/crawler/extractors.py
@@ -153,7 +153,7 @@ class UIDExtractor(URLInfoExtractor):
 
     def extract_value(self, resource_info):
         url = resource_info.url_info['loc']
-        hash_ = hashlib.md5(url)
+        hash_ = hashlib.md5(url.encode("utf-8"))
         uid = UUID(bytes=hash_.digest())
         return unicode(uid)
 


### PR DESCRIPTION
This solves an issue where generating the MD5 hash of an url can not be done
because of a non-ascii character in the url (e.g. "—", not a regular dash!)

Other crawlers should still work just fine as before. This change is able to potentially change the UID of indexed objects, which should not cause any damage.