### PR TITLE
Fix purging problem when providing sitemap url.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -136,6 +136,18 @@ forwarded to ``bin/crawl``.
 Therefore running ``bin/crawl-foo-org [args]`` is equivalent to
 ``bin/crawl foo_org_config.py [args]``.
 
+Provide known sitemap urls in site configs
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+If you know the sitemap url, you can configure one or many sitemap urls
+statically:
+
+.. code:: python
+
+    Site('http://example.org/foo/',
+         sitemap_urls=['http://example.org/foo/the_sitemap.xml'])
+
+
 Indexing only a particular URL
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -2,11 +2,14 @@ Changelog
 =========
 
 
-1.2.2 (unreleased)
+1.3.0 (unreleased)
 ------------------
 
-- Nothing changed yet.
-
+- Fix purging problem.
+  Warning: updating "ftw.crawler" to this version breaks your existing crawlers
+  when you set the site url to a sitemap url. Please use the "sitemap_urls"
+  attribute instead. You also need to purge the Solr index manually and reindex.
+  [jone]
 
 1.2.1 (2017-10-30)
 ------------------

--- a/ftw/crawler/configuration.py
+++ b/ftw/crawler/configuration.py
@@ -64,9 +64,11 @@ class Config(object):
 
 class Site(object):
 
-    def __init__(self, url, attributes=None, sleeptime=0.1):
+    def __init__(self, url, attributes=None, sleeptime=0.1,
+                 sitemap_urls=None):
         self.url = url
         self.sleeptime = sleeptime
+        self.sitemap_urls = sitemap_urls
 
         if attributes is None:
             attributes = {}

--- a/ftw/crawler/sitemap.py
+++ b/ftw/crawler/sitemap.py
@@ -9,8 +9,8 @@ import logging
 import requests
 
 
-SITEMAP_INDEX_NAMES = ('', 'sitemap_index.xml', 'sitemap_index.xml.gz')
-SITEMAP_NAMES = ('', 'sitemap.xml', 'sitemap.xml.gz')
+SITEMAP_INDEX_NAMES = ('sitemap_index.xml', 'sitemap_index.xml.gz')
+SITEMAP_NAMES = ('sitemap.xml', 'sitemap.xml.gz')
 SITEMAP_NS = 'http://www.sitemaps.org/schemas/sitemap/0.9'
 PROPERTIES = ('loc', 'lastmod', 'changefreq', 'priority', 'target')
 
@@ -29,6 +29,10 @@ class SitemapIndexFetcher(object):
         returning a ``SitemapIndex`` object.
         """
         log.info(u'Fetching sitemap index for {}'.format(self.site.url))
+        if self.site.sitemap_urls:
+            sitemaps = map(SitemapFetcher(self.site).fetch, self.site.sitemap_urls)
+            return VirtualSitemapIndex(self.site, sitemaps=sitemaps)
+
         for sm_idx_name in SITEMAP_INDEX_NAMES:
             url = urljoin(self.site.url, sm_idx_name)
             response = requests.get(url, allow_redirects=False)
@@ -121,6 +125,10 @@ class VirtualSitemapIndex(SitemapIndex):
         self.site = site
         self._sitemaps = sitemaps
         self.url = url
+
+    @property
+    def sitemaps(self):
+        return self._sitemaps
 
     @property
     def sitemap_infos(self):

--- a/ftw/crawler/tests/test_sitemap.py
+++ b/ftw/crawler/tests/test_sitemap.py
@@ -119,20 +119,6 @@ class TestSitemapFetcher(SitemapTestCase):
         sitemap = sm_fetcher.fetch()
         self.assertEquals(2, len(sitemap.url_infos))
 
-    @patch('requests.get')
-    def test_supports_absolute_sitemap_urls(self, request):
-        responses = {
-            'http://example.org/foo/bar/seitenkarte': MockResponse(
-                status_code=200,
-                content=SITEMAP),
-        }
-        request.side_effect = lambda url: responses[url]
-
-        site = Site('http://example.org/foo/bar/seitenkarte')
-        sm_fetcher = SitemapFetcher(site)
-        sitemap = sm_fetcher.fetch()
-        self.assertEquals(2, len(sitemap.url_infos))
-
 
 class TestSitemap(SitemapTestCase):
 
@@ -308,13 +294,18 @@ class TestSitemapIndexFetcher(SitemapTestCase):
     @patch('requests.get')
     def test_supports_absolute_sitemap_index_urls(self, request):
         responses = {
-            'http://example.org/foo/bar/seitenverzeichnisse': MockResponse(
+            'http://example.org/foo/bar/sitemap1.xml': MockResponse(
+                status_code=200,
+                content=SITEMAP_INDEX),
+            'http://example.org/foo/bar/sitemap2.xml': MockResponse(
                 status_code=200,
                 content=SITEMAP_INDEX),
         }
         request.side_effect = lambda url, **kwargs: responses[url]
 
-        site = Site('http://example.org/foo/bar/seitenverzeichnisse')
+        site = Site('http://example.org/foo/',
+                    sitemap_urls=['http://example.org/foo/bar/sitemap1.xml',
+                                  'http://example.org/foo/bar/sitemap2.xml'])
         sm_idx_fetcher = SitemapIndexFetcher(site)
         sitemap_index = sm_idx_fetcher.fetch()
-        self.assertEquals(2, len(sitemap_index.sitemap_infos))
+        self.assertEquals(2, len(sitemap_index.sitemaps))

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 import os
 
-version = '1.2.2.dev0'
+version = '1.3.0.dev0'
 
 tests_require = [
     'unittest2',


### PR DESCRIPTION
Purging is based on the site base url (the first argument for Site): the documents in Solr are identified by looking if they start with this site base url.

By making it possible to provide a sitemap url as first argument to Site, the purging broke, because the indexed document urls do not start with the sitemap (!) url.

This change removes the functionality to provide a sitemap url directly as first argument. Instead, the sitemap_urls keyword argument must be used, where a list of sitemap urls is provided.

All existing configurations with a sitemap url configured explicitly must be updated when updating ftw.crawler. For the affected sites the administrator should purge the solr index manually and reindex.

### Site configuration update
Sitemap URLs must now be listed explicitly, e.g.:
```diff
 CONFIG = Config(
     sites=[
-        Site('https://stadt.winterthur.ch/_vk/cal_1/sitemap/',
+        Site('https://stadt.winterthur.ch/_vk/cal_1/',
+             sitemap_urls=['https://stadt.winterthur.ch/_vk/cal_1/sitemap/'],
              attributes={'site_area': 'Stadt Winterthur'}),
     ],
 )
```