### PR TITLE
Add crawler_site_id option for improving purging.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -148,6 +148,22 @@ statically:
          sitemap_urls=['http://example.org/foo/the_sitemap.xml'])
 
 
+Configure site ID for purging
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+In order for the purging to work smoothly it is recommend to configure a
+crawler site ID.
+Make sure that each site ID is unique per solr core!
+Candidate documents for purging will be identified by this crawler site id.
+
+.. code:: python
+
+    Site('http://example.org/',
+         crawler_site_id='example.org-news')
+
+Be aware that your solr core must provide a string-field ``crawler_site_id``.
+
+
 Indexing only a particular URL
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,8 +5,7 @@ Changelog
 1.3.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
-
+- Add crawler_site_id option for improving purging. [jone]
 
 1.3.0 (2017-11-03)
 ------------------

--- a/ftw/crawler/configuration.py
+++ b/ftw/crawler/configuration.py
@@ -65,10 +65,11 @@ class Config(object):
 class Site(object):
 
     def __init__(self, url, attributes=None, sleeptime=0.1,
-                 sitemap_urls=None):
+                 sitemap_urls=None, crawler_site_id=None):
         self.url = url
         self.sleeptime = sleeptime
         self.sitemap_urls = sitemap_urls
+        self.crawler_site_id = crawler_site_id
 
         if attributes is None:
             attributes = {}

--- a/ftw/crawler/main.py
+++ b/ftw/crawler/main.py
@@ -47,7 +47,11 @@ def display_fields(field_values):
 
 
 def get_indexed_docs(config, solr, site):
-    query = '{}:{}*'.format(config.url_field, solr_escape(site.url))
+    if site.crawler_site_id is not None:
+        query = 'crawler_site_id:{}'.format(site.crawler_site_id)
+    else:
+        query = '{}:{}*'.format(config.url_field, solr_escape(site.url))
+
     indexed_docs = solr.search(
         query,
         fl=(config.unique_field, config.url_field, config.last_modified_field))
@@ -145,6 +149,8 @@ def crawl_site(tempdir, config, options, solr, site):
             field_values = engine.extract_field_values()
             display_fields(field_values)
             os.unlink(resource_info.filename)
+            if site.crawler_site_id:
+                field_values['crawler_site_id'] = site.crawler_site_id
 
             # Index into Solr
             log.debug(u"Indexing {} into solr.".format(url))


### PR DESCRIPTION
By configuring a crawler_site_id purging can be optimized. The crawler_site_id allows the crawler to easily identify all documents which were inserted by this crawler site, so that they can be purged reliably.

This allows to have multiple crawlers for the same site by configuring uniqe site ids for each site.
Make sure that the crawler have a string-field "crawler_site_id".